### PR TITLE
Use virtualenv to set up environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Based on [this repo](http://drivendata.github.io/cookiecutter-data-science/) fro
 
 ### Requirements to use the template:
 -----------
- - Python 2.7 or 3.5
+ - Python 3.5+
  - [Cookiecutter Python package](http://cookiecutter.readthedocs.org/en/latest/installation.html) >= 1.4.0: This can be installed with pip by or conda depending on how you manage your Python packages:
 
 ``` bash
@@ -43,7 +43,7 @@ git push origin master
 ### The resulting directory structure
 ------------
 
-The directory structure of your new project looks like this: 
+The directory structure of your new project looks like this:
 
 ```
 ├── LICENSE

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name": "project_name",
+    "project_name": "mdst_project",
     "repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
     "author_name": "Your name (or your organization/company/team)",
     "description": "A short description of the project.",

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -4,6 +4,7 @@
 # GLOBALS                                                                       #
 #################################################################################
 
+SHELL := /bin/bash
 PROJECT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 BUCKET = {{ cookiecutter.s3_bucket }}
 PROFILE = {{ cookiecutter.aws_profile }}
@@ -56,21 +57,20 @@ endif
 
 ## Set up python interpreter environment
 create_environment:
-	if command -v python3 &>/dev/null; then
-		@echo ">>> Creating virtualenv in env/"
-	else
-		@echo ">>> python3 is not installed. Install python3 and try again."
-	fi
-	python3 -m venv --upgrade env
-	@echo ">>> New virtualenv created. Activate with `make start`"
-
-## Activate virtualenv
-start:
-	source $(PROJECT_DIR)/env/bin/activate
+	@echo ">>> Creating virtualenv in env/"
+	@python3 -m venv env
+	# the following line creates a .envrc file for tools like direnv:
+	# https://direnv.net/
+	@echo 'source $(PROJECT_DIR)/env/bin/activate' > .envrc
+	@echo ">>> Installing packages from requirements.txt"
+	@source $(PROJECT_DIR)/env/bin/activate
+	@$(PROJECT_DIR)/env/bin/python -m pip install -r requirements.txt
+	@echo ">>> New virtualenv created. Activate with 'source env/bin/activate' in project root"
 
 ## Start Jupyter notebook in the virtual environment
 notebook:
-	$(PROJECT_DIR)/env/bin/jupyter-notebook
+	@source $(PROJECT_DIR)/env/bin/activate
+	$(PROJECT_DIR)/env/bin/jupyter-notebook $(PROJECT_DIR)/notebooks
 
 ## Test python environment is setup correctly
 test_environment:

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean data lint requirements sync_data_to_s3 sync_data_from_s3
+.PHONY: start clean data lint requirements sync_data_to_s3 sync_data_from_s3
 
 #################################################################################
 # GLOBALS                                                                       #
@@ -56,21 +56,21 @@ endif
 
 ## Set up python interpreter environment
 create_environment:
-ifeq (True,$(HAS_CONDA))
-		@echo ">>> Detected conda, creating conda environment."
-ifeq (3,$(findstring 3,$(PYTHON_INTERPRETER)))
-	conda create --name $(PROJECT_NAME) python=3
-else
-	conda create --name $(PROJECT_NAME) python=2.7
-endif
-		@echo ">>> New conda env created. Activate with:\nsource activate $(PROJECT_NAME)"
-else
-	$(PYTHON_INTERPRETER) -m pip install -q virtualenv virtualenvwrapper
-	@echo ">>> Installing virtualenvwrapper if not already intalled.\nMake sure the following lines are in shell startup file\n\
-	export WORKON_HOME=$$HOME/.virtualenvs\nexport PROJECT_HOME=$$HOME/Devel\nsource /usr/local/bin/virtualenvwrapper.sh\n"
-	@bash -c "source `which virtualenvwrapper.sh`;mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)"
-	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
-endif
+	if command -v python3 &>/dev/null; then
+		@echo ">>> Creating virtualenv in env/"
+	else
+		@echo ">>> python3 is not installed. Install python3 and try again."
+	fi
+	python3 -m venv --upgrade env
+	@echo ">>> New virtualenv created. Activate with `make start`"
+
+## Activate virtualenv
+start:
+	source $(PROJECT_DIR)/env/bin/activate
+
+## Start Jupyter notebook in the virtual environment
+notebook:
+	$(PROJECT_DIR)/env/bin/jupyter-notebook
 
 ## Test python environment is setup correctly
 test_environment:

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -18,12 +18,18 @@ make create_environment
 
 3. Activate environment
 ```
-conda activate {{cookiecutter.project_name}}
+source env/bin/activate
 ```
+or, if you have [direnv](https://direnv.net/) installed, `direnv allow`.
 
 4. Preprocess the data
 ```
 make data
+```
+
+5. Start Jupyter Notebook
+```
+make notebook
 ```
 
 Project Organization

--- a/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/{{ cookiecutter.repo_name }}/requirements.txt
@@ -8,6 +8,10 @@ coverage
 awscli
 flake8
 python-dotenv>=0.5.1
+
+# jupyter
+ipython
+jupyter-notebook
 {% if cookiecutter.python_interpreter != 'python3' %}
 
 # backwards compatibility

--- a/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/{{ cookiecutter.repo_name }}/requirements.txt
@@ -11,9 +11,6 @@ python-dotenv>=0.5.1
 
 # jupyter
 ipython
-jupyter-notebook
-{% if cookiecutter.python_interpreter != 'python3' %}
-
-# backwards compatibility
-pathlib2
-{% endif %}
+jupyter
+notebook
+nbdime


### PR DESCRIPTION
- Remove conda environment management in lieu of lighter-weight (built into python3) virtualenvs.
- Add `make notebook` command to start jupyter notebook within the virtual environment, providing access to packages installed in the virtual environment
- Support [direnv](https://direnv.net/), which allows automatic loading of virtual environments.